### PR TITLE
fix: Improve Python symlink management in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN if [ -f /usr/lib/x86_64-linux-gnu/libcudnn_adv.so.8 ]; then \
     fi
 
 # Set up Python and pip
-RUN ln -s /usr/bin/python3.12 /usr/bin/python && \
+RUN if [ -L /usr/bin/python ]; then rm /usr/bin/python; fi && \
+    ln -s /usr/bin/python3.12 /usr/bin/python && \
     rm /usr/bin/python3 && \
     ln -s /usr/bin/python3.12 /usr/bin/python3 && \
     curl -fsSL https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \


### PR DESCRIPTION
- Safely remove existing Python symlink before creating new one
- Ensure clean Python 3.12 symlink configuration
- Prevent potential conflicts during Docker image build